### PR TITLE
글 작성 일정 공유 기능

### DIFF
--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/data/server/model/TripReviewModel.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/data/server/model/TripReviewModel.kt
@@ -28,6 +28,14 @@ class TripReviewModel {
     var tripReviewState = TripReviewState.TRIP_REVIEW_STATE_NORMAL
     // 데이터가 생성된 시간
     var tripReviewTimestamp = 0L
+    // 여행 일정 공유 제목
+    var tripReviewShareTitle:String = ""
+    // 여행 일정 공유 날짜
+    var tripReviewShareDate:String = ""
+    // 여행 일정 공유 장소
+    var tripReviewSharePlace= mutableListOf<String>()
+    // 여행 일정 공유 계획
+    var tripReviewSharePlan: MutableList<Map<String, String>> = mutableListOf()
 
     fun toTripReviewVO(): TripReviewVO {
         val tripReviewVO = TripReviewVO()

--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/data/server/repository/PlanRepository.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/data/server/repository/PlanRepository.kt
@@ -2,6 +2,7 @@ package com.lion.FinalProject_CarryOn_Anywhere.data.server.repository
 
 import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
+import com.lion.FinalProject_CarryOn_Anywhere.data.server.model.PlanModel
 import com.lion.FinalProject_CarryOn_Anywhere.data.server.vo.PlanVO
 import com.lion.FinalProject_CarryOn_Anywhere.data.server.vo.TripVO
 import kotlinx.coroutines.tasks.await
@@ -118,7 +119,27 @@ class PlanRepository {
                 documentRef.update("placeList", newPlaceList).await()
             }
         } catch (e: Exception) {
-            Log.e("PlanService", " Firestore PlanData 업데이트 실패: ${e.message}")
+            Log.e("PlanService", "${e.message}")
+        }
+    }
+
+    suspend fun getPlansByPlanDocumentId(planDocumentId: String): PlanVO? {
+        return try {
+            val firestore = FirebaseFirestore.getInstance()
+            val documentSnapshot = firestore.collection("PlanData")
+                .document(planDocumentId)
+                .get()
+                .await()
+
+            val planVO = documentSnapshot.toObject(PlanVO::class.java)
+            planVO?.apply {
+                placeList = documentSnapshot.get("placeList") as? MutableList<Map<String, Any?>> ?: mutableListOf()
+            }
+
+            planVO
+        } catch (e: Exception) {
+            Log.e("PlanRepository","${e.message}")
+            null
         }
     }
 }

--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/data/server/service/PlanService.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/data/server/service/PlanService.kt
@@ -35,4 +35,9 @@ class PlanService(val planRepository: PlanRepository) {
     suspend fun deleteAllPlansByTripId(tripDocumentId:String){
         planRepository.deleteAllPlansByTripId(tripDocumentId)
     }
+
+    suspend fun getPlansByTripDocumentId(planDocumentId: String): PlanVO? {
+        return planRepository.getPlansByPlanDocumentId(planDocumentId)
+    }
+
 }

--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/screen/social/ReviewScreen.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/screen/social/ReviewScreen.kt
@@ -129,7 +129,7 @@ private fun ReviewCard(review: Review, onClick: () -> Unit) {
 
             // 여행 기간
             Text(
-                text = "여행 기간",
+                text = review.tripDate,
                 style = MaterialTheme.typography.bodySmall,
                 color = Color.Gray,
                 modifier = Modifier.padding(vertical = 5.dp)

--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/screen/social/SharingScreen.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/screen/social/SharingScreen.kt
@@ -3,6 +3,7 @@ package com.lion.FinalProject_CarryOn_Anywhere.ui.screen.social
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -22,10 +23,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -39,11 +43,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.lion.FinalProject_CarryOn_Anywhere.CarryOnApplication
 import com.lion.FinalProject_CarryOn_Anywhere.component.LikeLionEmptyView
 import com.lion.FinalProject_CarryOn_Anywhere.component.LikeLionFilledButton
 import com.lion.FinalProject_CarryOn_Anywhere.component.LikeLionTopAppBar
+import com.lion.FinalProject_CarryOn_Anywhere.ui.theme.SubColor
 import com.lion.FinalProject_CarryOn_Anywhere.ui.viewmodel.social.Share
 import com.lion.FinalProject_CarryOn_Anywhere.ui.viewmodel.social.SharingViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,9 +60,27 @@ fun SharingScreen(
     sharingViewModel: SharingViewModel = hiltViewModel(),
     navController: NavController,
 ) {
+    // 로딩 상태 감지
+    val isLoading by sharingViewModel.isLoading.collectAsState()
     val shares by sharingViewModel.shares.collectAsState()
 
-    Column (
+    val context = LocalContext.current
+
+    // 현재 로그인한 사용자 정보 가져오기 (안전한 null 체크)
+    val carryOnApplication = context.applicationContext as? CarryOnApplication
+    val loginUserId = try {
+        carryOnApplication?.loginUserModel?.userDocumentId ?: "guest"
+    } catch (e: UninitializedPropertyAccessException) {
+        "guest"
+    }
+
+    // `fetchUserTripReviews(loginUserId)` 호출 (loginUserId를 ViewModel로 넘김)
+    LaunchedEffect(Unit) {
+        sharingViewModel.fetchUserTripReviews(loginUserId)
+    }
+
+
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White) // 배경색을 흰색으로 설정
@@ -68,13 +95,31 @@ fun SharingScreen(
             }
         )
 
+        // Firestore에서 데이터를 가져오는 동안 로딩 표시
+        if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator(color = SubColor)
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Text("데이터를 불러오는 중...", color = Color.Gray)
+                }
+            }
+            return
+        }
+
         if (shares.isEmpty()) {
             LikeLionEmptyView(message = "저장된 일정이 없습니다.")
         } else {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()),
+                    .padding(
+                        bottom = WindowInsets.navigationBars.asPaddingValues()
+                            .calculateBottomPadding()
+                    ),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 contentPadding = PaddingValues(bottom = 20.dp)
             ) {
@@ -95,9 +140,6 @@ private fun ShareItem(share: Share, navController: NavController, index: Int) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 5.dp, horizontal = 15.dp)
-            .clickable {
-                navController.navigate("storyDetail/$index")
-            }
     ) {
         Row(
             modifier = Modifier
@@ -124,9 +166,9 @@ private fun ShareItem(share: Share, navController: NavController, index: Int) {
 
                 Spacer(modifier = Modifier.height(6.dp))
 
-                // 작성자 · 작성 날짜
+                // 작성 날짜
                 Text(
-                    text = share.date,
+                    text = "${formattedDate(share.startDateTime)} ~ ${formattedDate(share.endDateTime)}",
                     fontSize = 12.sp,
                     color = Color.LightGray
                 )
@@ -139,19 +181,41 @@ private fun ShareItem(share: Share, navController: NavController, index: Int) {
                 horizontalAlignment = Alignment.End,
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
+                // 사용자가 일정 선택 시 해당 정보를 PostScreen에 전달
                 LikeLionFilledButton(
                     text = "선택",
                     cornerRadius = 100,
-                    fillWidth = false, // 가로 길이를 자동 조정하도록 설정
-                    modifier = Modifier
-                        .wrapContentSize(), // 버튼 크기를 내부 컨텐츠(텍스트) 크기에 맞춤
+                    fillWidth = false,
+                    modifier = Modifier.wrapContentSize(),
                     onClick = {
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("selectedTitle", share.title)
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("startDateTime", formattedDate(share.startDateTime))
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("endDateTime", formattedDate(share.endDateTime))
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("tripCityList", share.tripCityList)
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("planList", share.planList)
                         navController.popBackStack()
                     }
                 )
             }
         }
     }
+}
+
+// 날짜 변환
+private fun formattedDate(timestamp: Long): String {
+    val date = Date(timestamp)
+    val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    return format.format(date)
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/viewmodel/social/ReviewViewModel.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/viewmodel/social/ReviewViewModel.kt
@@ -26,7 +26,11 @@ data class Review(
     val content: String,
     val postDate: Long,
     val likes: Int,
-    val comments: Int
+    val comments: Int,
+    val tripDate: String,
+    val shareTitle: String ,
+    val sharePlace: List<String>,
+    val sharePlan: List<Map<String, String>>
 )
 
 @HiltViewModel
@@ -64,7 +68,11 @@ class ReviewViewModel @Inject constructor(
                             postDate = tripReview.tripReviewTimestamp,
                             content = tripReview.tripReviewContent,
                             author = tripReview.userDocumentId,
-                            nickName = tripReview.userName
+                            nickName = tripReview.userName,
+                            tripDate = tripReview.tripReviewShareDate,
+                            shareTitle = tripReview.tripReviewShareTitle,
+                            sharePlace = tripReview.tripReviewSharePlace,
+                            sharePlan = tripReview.tripReviewSharePlan
                         )
                     }.sortedByDescending { it.postDate }
 

--- a/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/viewmodel/social/SharingViewModel.kt
+++ b/app/src/main/java/com/lion/FinalProject_CarryOn_Anywhere/ui/viewmodel/social/SharingViewModel.kt
@@ -1,31 +1,75 @@
 package com.lion.FinalProject_CarryOn_Anywhere.ui.viewmodel.social
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.maps.model.LatLng
+import com.lion.FinalProject_CarryOn_Anywhere.data.server.model.TripModel
+import com.lion.FinalProject_CarryOn_Anywhere.data.server.service.TripService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // 일정 공유 데이터 클래스
 data class Share(
+    val documentId: String,
     val title: String,
-    val date: String,
+    val resisterDate: Long,
+    val startDateTime: Long,
+    val endDateTime: Long,
+    val tripCityList: List<Map<String, Any>> = emptyList(),
+    val planList: List<Map<String, Any>> = emptyList()
 )
+
 @HiltViewModel
 class SharingViewModel @Inject constructor(
-    @ApplicationContext context: Context
+    private val tripService: TripService
 ) : ViewModel() {
 
-    private val _shares = MutableStateFlow(
-        listOf(
-            Share("서울 맛집 투어", "2025-02-12"),
-            Share("부산 오션뷰 호텔", "2025-02-10"),
-            Share("강릉 여행 코스", "2025-01-25"),
-            Share("서울 맛집 투어", "2025-02-12"),
-        )
-    )
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> get() = _isLoading
 
-    val shares: StateFlow<List<Share>> = _shares
+    private val _shares = MutableStateFlow<List<Share>>(emptyList())
+    val shares: StateFlow<List<Share>> get() = _shares
+
+    // ✅ loginUserId를 파라미터로 받도록 변경
+    fun fetchUserTripReviews(loginUserId: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                if (loginUserId == "guest") {
+                    _shares.value = emptyList() // 비회원이면 일정 없음
+                    return@launch
+                }
+
+                // TripService를 통해 특정 유저의 일정 가져오기
+                val tripData: List<TripModel> = tripService.gettingTripList(loginUserId)
+
+                // TripModel → Share 변환
+                val shareList = tripData.map { trip ->
+                    Share(
+                        documentId = trip.tripDocumentId,
+                        title = trip.tripTitle,
+                        resisterDate = trip.tripTimeStamp,
+                        startDateTime = trip.tripStartDate,
+                        endDateTime = trip.tripEndDate,
+                        tripCityList = trip.tripCityList.mapNotNull { it as? Map<String, Any> },
+                        planList = trip.planList.map { plan ->
+                            mapOf("id" to plan)
+                        }
+                    )
+                }.sortedByDescending { it.resisterDate }
+
+                _shares.value = shareList
+            } catch (e: Exception) {
+                Log.e("SharingViewModel", "데이터 불러오기 실패: ${e.message}")
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
 }


### PR DESCRIPTION
TripReview
 - model
1. 여행 일정 공유 제목 변수 추가
2. 여행 일정 공유 날짜 변수 추가
3. 여행 일정 공유 장소 변수 추가 
4. 여행 일정 공유 계획 변수 추가
 - screen, viewModel
1. 일정 기간 보이도록 코드 추가

TripReviewDetail
 - screen, viewModel
1. 공유 일정 보이도록 코드 추가
2. 구글 맵을 사용한 핀 (미구현)

Post
 - screen, viewModel
1. 일정 공유 버튼을 눌러서 돌아오면 제목 및 내용이 사라지는 문제 해결
2. 일정 공유 화면에서 일정 선택을 하면 해당 화면에 PlanData, TripData 표시
3. 저장 버튼을 누르면 TripReviewData에 공유 제목, 기간, 장소, 계획 저장
4. 구글 맵을 사용한 핀 (미구현)

Sharing
 - screen, viewModel
1. 로그인 한 유저의 일정을 불러온다.
2. 일정 선택 시 해당 제목, 기간, 장소, 계획 등 Data를 PostScreen으로 전달 코드 작성


Plan
 - Repository, Service
1. documentId로 해당 ID의 정보 불러 오는 코드 추가
